### PR TITLE
Minor fixes from other projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+coverage/
 node_modules/
 Brewfile.lock.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["editorconfig.editorconfig", "ms-vscode.powershell"]
+  "recommendations": ["editorconfig.editorconfig", "ms-vscode.powershell", "orta.vscode-jest"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.rulers": [100],
+  "jest.showCoverageOnLoad": true,
   "powershell.codeFormatting.preset": "OTBS",
   "workbench.colorCustomizations": {
     "statusBar.background": "#68A063"

--- a/script/bin/bootstrap
+++ b/script/bin/bootstrap
@@ -214,5 +214,5 @@ then
   npm install
 
   output_message "Checking for outdated packages..."
-  npm outdated
+  npm outdated || true
 fi

--- a/script/bin/check_scripts
+++ b/script/bin/check_scripts
@@ -26,12 +26,15 @@ else
   cd "$(dirname "$0")/../.." || exit
   echo "Change directory to: $(pwd)"
 
-  # Find all regular files, excluding the .git and node_modules folders, that contain shebang as
-  # shell script then redirect that list into a while loop to process each one individually.
+  # Find all regular files, excluding certain folders, that contain shebang as shell script then
+  # redirect that list into a while loop to process each one individually.
   while read -r -d '' script_file
   do
     check_script "${script_file}"
-  done < <(find . -type f ! -path './.git/*' ! -path './node_modules/*' \
+  done < <(find . \
+    -path './.git' -prune -o \
+    -path './node_modules' -prune -o \
+    -type f \
     -exec grep -qE '^#!(.*\/|.*\/env +)(sh|bash|ksh)' {} \; -print0)
 fi
 


### PR DESCRIPTION
Improve bash script checker by excluding specific folders without having to traverse them.
Continue even if there are outdated npm packages in the bash bootstrap script.